### PR TITLE
Remove deprecated 'bottle :unneeded'

### DIFF
--- a/Formula/antibody.rb
+++ b/Formula/antibody.rb
@@ -3,7 +3,6 @@ class Antibody < Formula
   desc "The fastest shell plugin manager"
   homepage "http://getantibody.github.io"
   version "6.1.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/getantibody/antibody/releases/download/v6.1.1/antibody_Darwin_x86_64.tar.gz"
@@ -23,7 +22,7 @@ class Antibody < Formula
       end
     end
   end
-  
+
   depends_on "git"
 
   def install


### PR DESCRIPTION
Homebrew is currently displaying a warning when using this tap, as `bottle :unneeded` is deprecated.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the getantibody/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/getantibody/homebrew-tap/Formula/antibody.rb:6
```

This PR removes the deprecated and now meaningless option.