### PR TITLE
Omit `bottle: unneeded` due to deperecation

### DIFF
--- a/Formula/antibody.rb
+++ b/Formula/antibody.rb
@@ -3,7 +3,6 @@ class Antibody < Formula
   desc "The fastest shell plugin manager"
   homepage "http://getantibody.github.io"
   version "6.1.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/getantibody/antibody/releases/download/v6.1.1/antibody_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
Omitted `bottle: unneeded`

## Motivation
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the getantibody/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/getantibody/homebrew-tap/Formula/antibody.rb:6