### PR TITLE
Fix homebrew warning

### DIFF
--- a/Formula/antibody.rb
+++ b/Formula/antibody.rb
@@ -3,7 +3,6 @@ class Antibody < Formula
   desc "The fastest shell plugin manager"
   homepage "http://getantibody.github.io"
   version "6.1.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/getantibody/antibody/releases/download/v6.1.1/antibody_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
Dropped the deprecated `bottle :unneeded`

I noticed that you are generating this with go-releases, might need to fix it there as well.